### PR TITLE
Test target adds C++14 features

### DIFF
--- a/code/tests/CMakeLists.txt
+++ b/code/tests/CMakeLists.txt
@@ -45,7 +45,13 @@ function(CedarFramework_AddTest)
             ${PARAM_ADDITIONAL_SOURCES}
             ${PARAM_ADDITIONAL_HEADERS}
         )
-
+    #	
+	set_target_properties(${PARAM_TEST_NAME} PROPERTIES
+        CXX_STANDARD 14
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+    )
+    
     target_include_directories(${PARAM_TEST_NAME} PUBLIC
             ${CMAKE_CURRENT_BINARY_DIR}
         )


### PR DESCRIPTION
The test target will fail the test if it does not use C++14 features